### PR TITLE
feat: add sample database seeding

### DIFF
--- a/cdpp/sv/package.json
+++ b/cdpp/sv/package.json
@@ -7,7 +7,8 @@
     "sv:start": "tsx watch src/index.ts",
     "sv:type-check": "tsc --noEmit",
     "sv:build": "tsc && tsc-alias",
-    "sv:prod": "node dist/index.js"
+    "sv:prod": "node dist/index.js",
+    "sv:seed": "tsx src/db/seed/index.ts"
   },
 
   "dependencies": {

--- a/cdpp/sv/src/db/seed/index.ts
+++ b/cdpp/sv/src/db/seed/index.ts
@@ -1,1 +1,40 @@
-export const init = () => {};
+import { getDB } from "@db/index.js";
+import { migrateAll } from "@db/migrations/index.js";
+
+export const init = async () => {
+    // Ensure database schema is ready
+    await migrateAll();
+    const db = await getDB();
+
+    // Clear existing data
+    await db.exec("DELETE FROM bookings; DELETE FROM users;");
+
+    // Seed sample users
+    const { lastID: aliceId } = await db.run(
+        "INSERT INTO users (name, email) VALUES (?, ?)",
+        ["Alice", "alice@example.com"],
+    );
+    const { lastID: bobId } = await db.run(
+        "INSERT INTO users (name, email) VALUES (?, ?)",
+        ["Bob", "bob@example.com"],
+    );
+
+    // Seed sample bookings linked to users
+    await db.run(
+        "INSERT INTO bookings (user_id, source_id, amount, created_at) VALUES (?, ?, ?, ?)",
+        [aliceId, 1, 100.0, Date.now()],
+    );
+    await db.run(
+        "INSERT INTO bookings (user_id, source_id, amount, created_at) VALUES (?, ?, ?, ?)",
+        [bobId, 2, 200.0, Date.now()],
+    );
+
+    console.log("✅ Sample data seeded");
+};
+
+// Execute immediately when run as a script
+if (process.argv[1] && process.argv[1].endsWith("db/seed/index.ts")) {
+    init().catch((err) => {
+        console.error("❌ Failed to seed data:", err);
+    });
+}


### PR DESCRIPTION
## Summary
- add sample data seeding for users and bookings
- expose `sv:seed` npm script to run the seeding

## Testing
- `npm --prefix cdpp/sv run sv:type-check`
- `npm --prefix cdpp/sv run sv:seed`


------
https://chatgpt.com/codex/tasks/task_e_68b8180bd9f8833096e62b0258334c39