### PR TITLE
feat(db): add workflow and trigger schemas

### DIFF
--- a/cdpp/sv/src/db/entities/StepRun/index.ts
+++ b/cdpp/sv/src/db/entities/StepRun/index.ts
@@ -1,0 +1,22 @@
+import { DataTypes } from "sequelize";
+import Conn from "@db/index.js";
+import { MODEL_WORKFLOW_RUN } from "@db/entities/WorkflowRun/index.js";
+
+export const MODEL_STEP_RUN = "step_runs";
+
+export default Conn.define(
+    MODEL_STEP_RUN,
+    {
+        id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+        workflow_run_id: {
+            type: DataTypes.INTEGER,
+            references: { model: MODEL_WORKFLOW_RUN, key: "id" },
+        },
+        step_id: { type: DataTypes.STRING },
+        status: { type: DataTypes.STRING },
+        started_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+        finished_at: { type: DataTypes.DATE },
+        output: { type: DataTypes.JSON },
+    },
+    { timestamps: false, tableName: MODEL_STEP_RUN },
+);

--- a/cdpp/sv/src/db/entities/Trigger/index.ts
+++ b/cdpp/sv/src/db/entities/Trigger/index.ts
@@ -1,0 +1,20 @@
+import { DataTypes } from "sequelize";
+import Conn from "@db/index.js";
+import { MODEL_WORKFLOW } from "@db/entities/Workflow/index.js";
+
+export const MODEL_TRIGGER = "triggers";
+
+export default Conn.define(
+    MODEL_TRIGGER,
+    {
+        id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+        workflow_id: {
+            type: DataTypes.INTEGER,
+            references: { model: MODEL_WORKFLOW, key: "id" },
+        },
+        type: { type: DataTypes.STRING },
+        config: { type: DataTypes.JSON },
+        created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+    },
+    { timestamps: false, tableName: MODEL_TRIGGER },
+);

--- a/cdpp/sv/src/db/entities/Workflow/index.ts
+++ b/cdpp/sv/src/db/entities/Workflow/index.ts
@@ -1,0 +1,15 @@
+import { DataTypes } from "sequelize";
+import Conn from "@db/index.js";
+
+export const MODEL_WORKFLOW = "workflows";
+
+export default Conn.define(
+    MODEL_WORKFLOW,
+    {
+        id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+        name: { type: DataTypes.STRING },
+        definition: { type: DataTypes.JSON },
+        created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+    },
+    { timestamps: false, tableName: MODEL_WORKFLOW },
+);

--- a/cdpp/sv/src/db/entities/WorkflowRun/index.ts
+++ b/cdpp/sv/src/db/entities/WorkflowRun/index.ts
@@ -1,0 +1,20 @@
+import { DataTypes } from "sequelize";
+import Conn from "@db/index.js";
+import { MODEL_WORKFLOW } from "@db/entities/Workflow/index.js";
+
+export const MODEL_WORKFLOW_RUN = "workflow_runs";
+
+export default Conn.define(
+    MODEL_WORKFLOW_RUN,
+    {
+        id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+        workflow_id: {
+            type: DataTypes.INTEGER,
+            references: { model: MODEL_WORKFLOW, key: "id" },
+        },
+        status: { type: DataTypes.STRING },
+        started_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+        finished_at: { type: DataTypes.DATE },
+    },
+    { timestamps: false, tableName: MODEL_WORKFLOW_RUN },
+);

--- a/cdpp/sv/src/scripts/db-scripts.ts
+++ b/cdpp/sv/src/scripts/db-scripts.ts
@@ -1,16 +1,27 @@
-import {create, remove} from "@eventSource/index.js";
+import { create, remove } from "@eventSource/index.js";
 import path from "node:path";
-import {MODEL_USER} from "@db/entities/User/index.js";
-import {MODEL_BOOKING} from "@db/entities/Booking/index.js";
+import { MODEL_USER } from "@db/entities/User/index.js";
+import { MODEL_BOOKING } from "@db/entities/Booking/index.js";
+import { MODEL_WORKFLOW } from "@db/entities/Workflow/index.js";
+import { MODEL_TRIGGER } from "@db/entities/Trigger/index.js";
+import { MODEL_WORKFLOW_RUN } from "@db/entities/WorkflowRun/index.js";
+import { MODEL_STEP_RUN } from "@db/entities/StepRun/index.js";
 import * as process from "node:process";
-import Conn from '@db/index.ts';
+import Conn from "@db/index.ts";
 
-const arrModel = [MODEL_USER, MODEL_BOOKING];
+const arrModel = [
+    MODEL_STEP_RUN,
+    MODEL_WORKFLOW_RUN,
+    MODEL_TRIGGER,
+    MODEL_WORKFLOW,
+    MODEL_BOOKING,
+    MODEL_USER,
+];
 
 async function main() {
     await Conn.sync();
 
-    for (let model of arrModel) {
+    for (const model of arrModel) {
         await remove(model, {});
     }
 
@@ -40,11 +51,46 @@ async function main() {
         created_at: Date.now(),
     });
 
+    // Seed workflow and related data
+    const workflow = (await create(MODEL_WORKFLOW, {
+        name: "Sample Booking Workflow",
+        definition: {
+            steps: [{ id: "log-step", action: "log" }],
+        },
+        created_at: new Date(),
+    })) as any;
+
+    await create(MODEL_TRIGGER, {
+        workflow_id: workflow.id,
+        type: "bookings.created",
+        config: {},
+        created_at: new Date(),
+    });
+
+    const workflowRun = (await create(MODEL_WORKFLOW_RUN, {
+        workflow_id: workflow.id,
+        status: "completed",
+        started_at: new Date(),
+        finished_at: new Date(),
+    })) as any;
+
+    await create(MODEL_STEP_RUN, {
+        workflow_run_id: workflowRun.id,
+        step_id: "log-step",
+        status: "completed",
+        started_at: new Date(),
+        finished_at: new Date(),
+        output: { message: "booking logged" },
+    });
+
     console.log("✅ Sample data seeded");
 }
 
-const runAsScript = process.argv[1] && path.normalize(process.argv[1])
-    .endsWith(path.join("scripts", "db-scripts.ts"));
+const runAsScript =
+    process.argv[1] &&
+    path
+        .normalize(process.argv[1])
+        .endsWith(path.join("scripts", "db-scripts.ts"));
 
 if (runAsScript) {
     main().catch((err) => {


### PR DESCRIPTION
## Summary
- define Sequelize models for workflows, triggers, workflow runs, and step runs
- seed sample workflow, trigger, run, and step data

## Testing
- `npm run sv:type-check` *(fails: Cannot find module 'sequelize' or its corresponding type declarations)*
- `npm run sv:seed` *(fails: Cannot find package 'sequelize')*


------
https://chatgpt.com/codex/tasks/task_e_68b852e43f308330ab5f7f4891cc4552